### PR TITLE
use ksops-exec instead of ksops

### DIFF
--- a/manifests/argocd/overlays/prod/secrets/gpg/secret-generator.yaml
+++ b/manifests/argocd/overlays/prod/secrets/gpg/secret-generator.yaml
@@ -1,5 +1,5 @@
 apiVersion: viaduct.ai/v1
-kind: ksops
+kind: ksops-exec
 metadata:
   name: gpg-generator
 files:


### PR DESCRIPTION
I'm hitting what seems to be version skew or build environment issues
between the ksops plugin and kustomize. Rather than chasing those
down, let's just use the ksops-exec version of the ksops plugin, which
avoids both of those potential problems.